### PR TITLE
fix(hero-carousel): replace section with div to improve semantic structure

### DIFF
--- a/al-cakes78/src/components/Hero/HeroCarousel.tsx
+++ b/al-cakes78/src/components/Hero/HeroCarousel.tsx
@@ -38,7 +38,7 @@ const EmblaCarousel: React.FC<PropType> = ({ slides, options }) => {
   );
 
   return (
-    <section className={styles.embla}>
+    <div className={styles.embla}>
       <div className={styles.embla__viewport} ref={emblaRef}>
         <div className={styles.embla__container}>
           {slides.map((src, index) => (
@@ -68,7 +68,7 @@ const EmblaCarousel: React.FC<PropType> = ({ slides, options }) => {
           ))}
         </div>
       </div>
-    </section>
+    </div>
   );
 };
 


### PR DESCRIPTION
Fix semantic HTML in HeroCarousel by replacing nested <section> with <div>.